### PR TITLE
[iOS #50, #86] 이슈 리스트 서버 API 요청 추가

### DIFF
--- a/iOS/IssueTracker/IssueTracker/IssueDetail/Model/IssueDetailModel.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/Model/IssueDetailModel.swift
@@ -1,47 +1,53 @@
 import Foundation
 
-struct Comment: Hashable {
-    var title: String
-    var user: String
+struct Comment: Hashable, Codable {
+    
+    var cid: Int
     var content: String
+    var iid: Int
+    var uid: Int
+    var updatedAt: String
+    var createdAt: String
+//    var title: String
+//    var user: String
+//    var content: String
     
-    static func == (lhs: Comment, rhs: Comment) -> Bool {
-        lhs.title == rhs.title
-            && lhs.user == rhs.user
-            && lhs.content == rhs.content
-    }
+//    static func == (lhs: Comment, rhs: Comment) -> Bool {
+//        lhs.title == rhs.title
+//            && lhs.user == rhs.user
+//            && lhs.content == rhs.content
+//    }
+//
+//    func hash(into hasher: inout Hasher) {
+//        hasher.combine(title)
+//        hasher.combine(user)
+//        hasher.combine(content)
+//    }
     
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(title)
-        hasher.combine(user)
-        hasher.combine(content)
-    }
-    
-    static func all() -> [Comment] {
-        [
-            Comment(title: "dd", user: "조정래", content: "그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가"),
-            Comment(title: "그렇군", user: "정재명", content: "이잉유유으으으아아이잉유유으으으아잉유유으으으아아"),
-            Comment(title: "그러하다", user: "뿡뿡뽕뽕", content: "그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가"),
-            Comment(title: "그러하다", user: "뿡뿡뽕", content: "그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가"),
-            Comment(title: "그러하다", user: "뿡뿡뽕뽕뽕", content: "그런가그런가그런가그가그런가그런가그런그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가")
-        ]
-    }
+//    static func all() -> [Comment] {
+//        [
+//            Comment(title: "dd", user: "조정래", content: "그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가"),
+//            Comment(title: "그렇군", user: "정재명", content: "이잉유유으으으아아이잉유유으으으아잉유유으으으아아"),
+//            Comment(title: "그러하다", user: "뿡뿡뽕뽕", content: "그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가"),
+//            Comment(title: "그러하다", user: "뿡뿡뽕", content: "그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가"),
+//            Comment(title: "그러하다", user: "뿡뿡뽕뽕뽕", content: "그런가그런가그런가그가그런가그런가그런그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가그런가")
+//        ]
+//    }
 }
 
 
-struct IssueDetailModel: Hashable {
+struct IssueDetailModel: Hashable, Codable {
     
     var iid: Int
     var title: String // 이슈 타이틀
     var isOpen: Bool
     var label: [String]?
     var content: String?
-    
-    var comment: [Comment]?
-    
+    var comments: [Comment]?
+    var updatedAt: String?
     var createdAt: String?
-    var author: String
-    var milestone: [Milestone]
+    var author: String?
+    var mid: Int?
     var assignees: [Assignees]?
     
     static func == (lhs: IssueDetailModel, rhs: IssueDetailModel) -> Bool {
@@ -52,9 +58,9 @@ struct IssueDetailModel: Hashable {
             && lhs.content == rhs.content
             && lhs.createdAt == rhs.createdAt
             && lhs.author == rhs.author
-            && lhs.milestone == rhs.milestone
+            && lhs.mid == rhs.mid
             && lhs.assignees == rhs.assignees
-            && lhs.comment == rhs.comment
+            && lhs.comments == rhs.comments
     }
     
     func hash(into hasher: inout Hasher) {
@@ -65,14 +71,14 @@ struct IssueDetailModel: Hashable {
         hasher.combine(content)
         hasher.combine(createdAt)
         hasher.combine(author)
-        hasher.combine(milestone)
+        hasher.combine(mid)
         hasher.combine(assignees)
-        hasher.combine(comment)
+        hasher.combine(comments)
     }
     
 }
 
-struct Milestone: Hashable {
+struct Milestone: Hashable, Codable {
     
     var mid: String
     var title: String
@@ -91,7 +97,7 @@ struct Milestone: Hashable {
     }
 }
 
-struct IssueState: Hashable { // 이걸로 이슈 얼마나 열려있는지 확인
+struct IssueState: Hashable, Codable { // 이걸로 이슈 얼마나 열려있는지 확인
     
     var open: Int
     var close: Int
@@ -106,7 +112,7 @@ struct IssueState: Hashable { // 이걸로 이슈 얼마나 열려있는지 확�
     }
 }
 
-struct Assignees: Hashable {
+struct Assignees: Hashable, Codable {
     
     var uid: Int
     

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailViewController.swift
@@ -14,7 +14,6 @@ class IssueDetailViewController: UIViewController {
         super.viewDidLoad()
         configureNavigation()
         configureIsOpenView()
-        viewModel = IssueDetailViewModel(model: Comment.all())
         configureContainerOfSwipeView()
         viewModel?.status.model.bindAndFire(applySnapshot(sections:))
     }
@@ -32,7 +31,7 @@ class IssueDetailViewController: UIViewController {
             cellProvider: { (collectionview, indexPath, comment) -> UICollectionViewCell? in
                 let cell = collectionview.dequeueReusableCell(withReuseIdentifier: "IssueCommentCellView", for: indexPath) as? IssueCommentCellView
                 
-                cell?.setup(user: comment.user, content: comment.content)
+//                cell?.setup(user: comment.user, content: comment.content)
                 
                 return cell
             })

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/ViewModel/IssueDetailViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/ViewModel/IssueDetailViewModel.swift
@@ -1,9 +1,9 @@
 
 import Foundation
-
+import Alamofire
 class IssueDetailViewModel {
     struct Status {
-        var model: Bindable<[Comment]> // 여기에 snapshot 연결
+        var model =  Bindable<[Comment]>([Comment]()) // 여기에 snapshot 연결
     }
     
     struct Action {
@@ -15,9 +15,44 @@ class IssueDetailViewModel {
     
     var status: Status
     //var action: Action
+  
+    var iid: Int
     
-    init(model: [Comment]) {
-        self.status = Status(model: Bindable(model))
+//    init(model: [Comment]) {
+//        self.status = Status(model: Bindable(model))
+//    }
+//
+    init(iid: Int) {
+        self.status = Status()
+        self.iid = iid
+        callAPI()
     }
+
+    func callAPI() {
+        let url = "http://group05issuetracker.duckdns.org:49203"
+        
+        let parameters = ["issueID": String(self.iid)]
+
+        let headers: HTTPHeaders = ["Accept": "application/json","Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjExLCJ1c2VySWQiOiJhYWExMTEiLCJwYXNzd29yZCI6IiQyYiQxMiRFQmIxMDBuckJCRTZZSDhXSWNvam5PS3d5YlYzSUQ1VHE4U2x6RWxnRWdXUm0xRU9TOVQzMiIsIm5pY2tuYW1lIjoiYWFhMTExIiwiT0F1dGgiOmZhbHNlLCJyZXNvdXJjZVNlcnZlciI6ImxvY2FsIiwiY3JlYXRlZEF0IjoiMjAyMC0xMS0wM1QwODozMzozNy4wMDBaIiwidXBkYXRlZEF0IjoiMjAyMC0xMS0wM1QwODozMzozNy4wMDBaIiwiaWF0IjoxNjA0NDgxMTIzfQ.p4nu83YEYOTD5NB7XKkqJTyAlgKDu6EPVgLMQqHQ_RY"]
+        
+        AF.request(url + "/api/issue/\(self.iid)", method: .get, parameters: parameters, headers: headers).responseJSON { (response) in
+            switch response.result {
+            case .success(let result):
+                do {
+//                    self.status.model.value = Comment.all()
+                    print(result)
+                    let resultData = try JSONSerialization.data(withJSONObject: result, options: .prettyPrinted)
+                    let decodedData = try JSONDecoder().decode(IssueDetailModel.self, from: resultData)
+                    self.status.model.value = decodedData.comments!
+                } catch {
+                    print(error)
+                }
+            case .failure(let error):
+                print(error)
+            default: break
+            }
+        }
+    }
+    
     
 }

--- a/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueListMainViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueListMainViewController.swift
@@ -111,10 +111,13 @@ extension IssueListMainViewController: UICollectionViewDelegate {
         }
         //cell.iid 이걸 viewModel에 넘겨준다. viewModel이 생성하면서 서버와 통신하여 해당 iid의 이슈 데이터를 가져온다.
         
-        let newVC = UIStoryboard(name: "IssueDetail", bundle: nil).instantiateViewController(identifier: String(describing: IssueDetailViewController.self))
+        let newVC = UIStoryboard(name: "IssueDetail", bundle: nil).instantiateViewController(identifier: String(describing: IssueDetailViewController.self)) as! IssueDetailViewController
+        
+        newVC.viewModel = IssueDetailViewModel(iid: cell.iid ?? 0)
         
         // 초기화
         navigationController?.pushViewController(newVC, animated: true)
+        
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/IssueList/ViewModel/IssueListViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/ViewModel/IssueListViewModel.swift
@@ -39,8 +39,8 @@ class IssueListViewModel {
             weakSelf.requestIssueData()
         })
     
-    let url = "http://172.30.1.27:5000/api/issue"
-    let httpHeaders:HTTPHeaders = ["Accept": "application/json"]
+    let url = "http://group05issuetracker.duckdns.org:49203/api/issue"
+    let httpHeaders:HTTPHeaders = ["Accept": "application/json","Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjExLCJ1c2VySWQiOiJhYWExMTEiLCJwYXNzd29yZCI6IiQyYiQxMiRFQmIxMDBuckJCRTZZSDhXSWNvam5PS3d5YlYzSUQ1VHE4U2x6RWxnRWdXUm0xRU9TOVQzMiIsIm5pY2tuYW1lIjoiYWFhMTExIiwiT0F1dGgiOmZhbHNlLCJyZXNvdXJjZVNlcnZlciI6ImxvY2FsIiwiY3JlYXRlZEF0IjoiMjAyMC0xMS0wM1QwODozMzozNy4wMDBaIiwidXBkYXRlZEF0IjoiMjAyMC0xMS0wM1QwODozMzozNy4wMDBaIiwiaWF0IjoxNjA0NDgxMTIzfQ.p4nu83YEYOTD5NB7XKkqJTyAlgKDu6EPVgLMQqHQ_RY"]
     
     init() {
         requestIssueData()


### PR DESCRIPTION
- 이슈 리스트 및 상세 화면 API 통해 호출
- 코멘트 및 이슈리스트 모델 수정