### PR TITLE
[iOS] 다중 선택 화면 구현, 마일스톤 delete 버튼 구현, 이슈 상세화면 refresh 추가 

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		8875E989255856E60066146D /* MilestoneListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8875E988255856E60066146D /* MilestoneListCoordinator.swift */; };
 		888125AA255BE3C1000D0F20 /* MultiSelectiveEditingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888125A9255BE3C1000D0F20 /* MultiSelectiveEditingViewController.swift */; };
 		888125AE255BE701000D0F20 /* MultiSelectedEditing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 888125AD255BE701000D0F20 /* MultiSelectedEditing.storyboard */; };
+		889BFD99255CF2DB00021C11 /* MultiSelectiveEditingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889BFD98255CF2DB00021C11 /* MultiSelectiveEditingService.swift */; };
 		88B8F0FE254AB14400C23791 /* LabelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B8F0FD254AB14400C23791 /* LabelListViewController.swift */; };
 		88C03808254961BE000D4D4A /* IssueListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C03807254961BE000D4D4A /* IssueListViewModel.swift */; };
 		88C0380B254961E4000D4D4A /* IssueListMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C0380A254961E4000D4D4A /* IssueListMainViewController.swift */; };
@@ -132,6 +133,7 @@
 		8875E988255856E60066146D /* MilestoneListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneListCoordinator.swift; sourceTree = "<group>"; };
 		888125A9255BE3C1000D0F20 /* MultiSelectiveEditingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSelectiveEditingViewController.swift; sourceTree = "<group>"; };
 		888125AD255BE701000D0F20 /* MultiSelectedEditing.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MultiSelectedEditing.storyboard; sourceTree = "<group>"; };
+		889BFD98255CF2DB00021C11 /* MultiSelectiveEditingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSelectiveEditingService.swift; sourceTree = "<group>"; };
 		88B8F0F4254AB0F400C23791 /* MilestoneList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MilestoneList.storyboard; sourceTree = "<group>"; };
 		88B8F0F7254AB12000C23791 /* LabelList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LabelList.storyboard; sourceTree = "<group>"; };
 		88B8F0FA254AB13800C23791 /* MilestoneListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneListViewController.swift; sourceTree = "<group>"; };
@@ -416,10 +418,19 @@
 		888125A7255BE34D000D0F20 /* MultiSelectiveEditiView */ = {
 			isa = PBXGroup;
 			children = (
+				889BFD97255CF2C300021C11 /* Service */,
 				88DB3083255C069000EE80F3 /* View */,
 				88DB3082255C068A00EE80F3 /* ViewModel */,
 			);
 			path = MultiSelectiveEditiView;
+			sourceTree = "<group>";
+		};
+		889BFD97255CF2C300021C11 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				889BFD98255CF2DB00021C11 /* MultiSelectiveEditingService.swift */,
+			);
+			path = Service;
 			sourceTree = "<group>";
 		};
 		88B8F0F2254AB08500C23791 /* MilestoneList */ = {
@@ -955,6 +966,7 @@
 				DABEB867254821B3006471F6 /* AppDelegate.swift in Sources */,
 				DA8B33BB2552D6F000E3331F /* IssueDetailViewController.swift in Sources */,
 				88CB53A2255A2F5000C99A9A /* UIColor+.swift in Sources */,
+				889BFD99255CF2DB00021C11 /* MultiSelectiveEditingService.swift in Sources */,
 				DA1B56F8255024B000FE8D2D /* MilestoneListViewCell.swift in Sources */,
 				DA511AB5254AA3490036DDC3 /* LoginManager.swift in Sources */,
 				DAC37CF125510747000C2777 /* UIButton.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Common/BothSidesSwipingView.swift
+++ b/iOS/IssueTracker/IssueTracker/Common/BothSidesSwipingView.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 class BothSidesSwipingView: UIView {
+    
     var withDuration = 0.4
     var delay = 0.0
     var usingSpringWithDamping: CGFloat = 0.5

--- a/iOS/IssueTracker/IssueTracker/IssueCreation/View/IssueCreationViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueCreation/View/IssueCreationViewController.swift
@@ -6,14 +6,7 @@ class IssueCreationViewController: UIViewController {
     @IBOutlet weak var markdownSegmentedControl: UISegmentedControl!
     @IBOutlet weak var uploadButton: UIButton!
     
-//    @IBOutlet weak var titleTextView: UITextView! {
-//        didSet {
-//            titleTextView.delegate = self
-//        }
-//    }
-
     @IBOutlet weak var titleTextView: UITextField!
-    
     
     @IBOutlet weak var IssueNumberLabel: UILabel!
     
@@ -24,6 +17,9 @@ class IssueCreationViewController: UIViewController {
     }
     
     private let placeholderMessage = "코멘트는 여기에 작성하세요"
+    
+    var refresh: (()->Void)?
+    
     
     var viewModel = IssueCreationViewModel()
     
@@ -77,7 +73,9 @@ class IssueCreationViewController: UIViewController {
             self.viewModel.service.requestAddIssue(title: self.titleTextView.text!, content: markdownTextView.text)
         }
         
-        self.dismiss(animated: true)
+        self.dismiss(animated: true) { [weak self] in
+            self?.refresh?()
+        }
     }
     
     @IBAction func indexChanged(_ sender: UISegmentedControl) {

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/Service/IssueDetailService.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/Service/IssueDetailService.swift
@@ -16,11 +16,10 @@ class IssueDetailService {
                "Authorization": "Bearer \(UserDefaults.standard.string(forKey: "token")!)"]
     }
     
-    func callAPI(with issueId: Int) {
+    func requestIssueGet(with issueId: Int) {
         let parameters = ["issueID": String(issueId)]
         
         AF.request(url + "/api/issue/\(issueId)", method: .get, parameters: parameters, headers: headers).responseJSON { [weak self] (response) in
-            
             guard let weakSelf = self else { return }
             
             switch response.result {
@@ -29,20 +28,11 @@ class IssueDetailService {
                     print(result)
                     let resultData = try JSONSerialization.data(withJSONObject: result, options: .prettyPrinted)
                     let decodedData = try JSONDecoder().decode(IssueDetailModel.self, from: resultData)
-                    
                     weakSelf.viewModel.status.model.value = decodedData
-                    
-                    print("이슈 디테일 데이터", decodedData)
-                    
-                    
-                    //.. = weakSelf.viewModel.status.model.value.assignees
                 } catch {
-                    print("에러에러에러에러에러에러에러에러에러에러에러에러에러에러에러")
                     print(error)
                 }
             case .failure(let error):
-                print("에러에러에러에러에러에러에러에러에러에러에러에러에러에러에러")
-                print("error\nerror\n error\n error\n error\n error\n error\n error\n error ")
                 print(error)
             }
         }

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailEditing/Cell/MilestoneCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailEditing/Cell/MilestoneCollectionViewCell.swift
@@ -11,5 +11,4 @@ import UIKit
 class MilestoneCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var milestoneLabel: UILabel!
     @IBOutlet var milestoneProgressView: UIProgressView!
-    
 }

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailEditing/Cell/SectionHeader.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailEditing/Cell/SectionHeader.swift
@@ -8,10 +8,17 @@
 
 import UIKit
 
+protocol SectionHeaderDelegate {
+    func touchedEditButton(title: String)
+}
+
 class SectionHeader: UICollectionReusableView {
+    
+    var delegate: SectionHeaderDelegate?
+    
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var editButton: UIButton!
     @IBAction func touchedEditButton(_ sender: Any) {
-        
+        delegate?.touchedEditButton(title: titleLabel.text ?? "")
     }
 }

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailEditing/View/IssueDetailEditingViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailEditing/View/IssueDetailEditingViewController.swift
@@ -14,6 +14,29 @@ protocol IssueDetailEditingViewControllerDelegate {
     func addCommentButtonTabbed()
 }
 
+extension IssueDetailEditingViewController: SectionHeaderDelegate {
+    func touchedEditButton(title: String) {
+        if title == "레이블" {
+//            let vc: LabelListViewController
+//                = UIStoryboard(name: "LabelList", bundle: nil)
+//                .instantiateViewController(
+//                    identifier:String(describing: LabelListViewController.self))
+//
+//            navigationController?.modalPresentationStyle = .popover
+//            navigationController?
+//                .pushViewController(vc, animated: true)
+            //present(vc, animated: true, completion: nil)
+        } else if title == "마일스톤" {
+//            let vc: LabelListViewController
+//                = UIStoryboard(name: "MilestoneList", bundle: nil)
+//                .instantiateViewController(
+//                    identifier:String(describing: MilestoneListViewController.self))
+//            present(vc, animated: true, completion: nil)
+        }
+    }
+    
+}
+
 class IssueDetailEditingViewController: UIViewController {
     
     var delegate: IssueDetailEditingViewControllerDelegate?
@@ -32,13 +55,14 @@ class IssueDetailEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         collectionView.reloadData()
         collectionView.isScrollEnabled = false
         buttonsForInit.forEach {
             $0.configureButtonInDetailEditing()
         }
     }
-        
+    
     @IBAction func addCommentButtonTabbed(_ sender: UIButton) {
         delegate?.addCommentButtonTabbed()
     }
@@ -70,7 +94,7 @@ extension IssueDetailEditingViewController: UICollectionViewDataSource, UICollec
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         CGSize(width: collectionView.frame.width, height: 80)
     }
-        
+    
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         3
     }
@@ -86,7 +110,7 @@ extension IssueDetailEditingViewController: UICollectionViewDataSource, UICollec
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-
+        
         if indexPath.section == 0 {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "AssigneeCollectionViewCell", for: indexPath) as! AssigneeCollectionViewCell
             if let assignee = viewModel?.status.model.value.assignees?[indexPath.row] {
@@ -107,7 +131,7 @@ extension IssueDetailEditingViewController: UICollectionViewDataSource, UICollec
         } else {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MilestoneCollectionViewCell", for: indexPath) as! MilestoneCollectionViewCell
             cell.milestoneLabel.text = "\(String(describing: viewModel?.status.model.value.milestone?.title ?? ""))"
-
+            
             if let total = viewModel?.status.model.value.milestone?.issues?.count {
                 
                 let complete:Double = viewModel?.status.model.value.milestone?.issues?.reduce(0.0) { (s1, s2) in
@@ -117,20 +141,23 @@ extension IssueDetailEditingViewController: UICollectionViewDataSource, UICollec
                 cell.milestoneProgressView.progress = Float(complete / Double(total))
             }
             
-                
+            
             return cell
         }
         
     }
-     
+    
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         if let sectionHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "SectionHeader", for: indexPath) as? SectionHeader{
             if indexPath.section == 0 {
                 sectionHeader.titleLabel.text = "담당자"
+                sectionHeader.delegate = self
             } else if indexPath.section == 1 {
                 sectionHeader.titleLabel.text = "레이블"
+                sectionHeader.delegate = self
             } else {
                 sectionHeader.titleLabel.text = "마일스톤"
+                sectionHeader.delegate = self
             }
             return sectionHeader
         }

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailMain/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/View/IssueDetailMain/IssueDetailViewController.swift
@@ -16,26 +16,25 @@ class IssueDetailViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var containerView: UIView!
     
-    var isOpen = true  {// TODO: viewmodel에 바인딩 된 함수에서 바꿔준다.
+    var isOpen = true  { // TODO: viewmodel에 바인딩 된 함수에서 바꿔준다.
         didSet {
             configureIsOpenView()
         }
     }
+
+    
+    // MARK: View Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigation()
         configureIsOpenView()
-        collectionView.collectionViewLayout = createCompositionalList()
+        configureCollectionView()
         configureContainerOfSwipeView()
         if let viewModel = viewModel {
             viewModel.status.model.bindAndFire(updateViews(model:))
             return
         }
-        
-        // TODO: 나중에 제거해야 한다.
-        updateViews(model: IssueDetailModel.all())
-      
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -53,23 +52,29 @@ class IssueDetailViewController: UIViewController {
     }
     
     func updateViews(model: IssueDetailModel) {
-        
-        // 유저 이미지 - 아직은 없음
-        
         issueTitle.text = model.title
         issueNumber.text = "#\(model.iid)"
         isOpen = model.isOpen
-        
-        // 댓글 목록 -> apply
         if let comments = model.comments {
             applySnapshot(sections: comments)
         } else {
             applySnapshot(sections: Comment.all())
         }
-        
         swipeUpView.collectionView.reloadData()
-        
-        //swipeUpView update -> 담당자, 마일스톤, 레이블
+    }
+    
+    
+    // MARK: Collection View Config
+    func configureCollectionView() {
+        collectionView.collectionViewLayout = createCompositionalList()
+        collectionView.refreshControl = UIRefreshControl()
+        collectionView.refreshControl?.attributedTitle = NSAttributedString(string: "새로고침")
+        collectionView.refreshControl?.addTarget(self, action: #selector(refresh), for: .valueChanged)
+    }
+    
+    @objc func refresh() {
+        viewModel?.action.refreshData()
+        self.collectionView.refreshControl?.endRefreshing()
     }
     
     func applySnapshot(sections: [Comment]) {
@@ -128,6 +133,9 @@ class IssueDetailViewController: UIViewController {
         configureAnimation()
     }
     
+    
+    // MARK: Swipe View config
+    
     var swipeGesture: UISwipeGestureRecognizer!
     var oldY: CGFloat!
     var newY: CGFloat!
@@ -173,6 +181,7 @@ class IssueDetailViewController: UIViewController {
         creationVC.viewModel.status.id = viewModel?.issueId
         creationVC.viewModel.status.title = viewModel?.status.model.value.title ?? ""
         creationVC.viewModel.status.content = viewModel?.status.model.value.content ?? ""
+        creationVC.refresh = viewModel?.action.refreshData
         self.present(creationVC, animated: true)
         
     }
@@ -181,22 +190,22 @@ class IssueDetailViewController: UIViewController {
     
 }
 
+
+// MARK: IssueDetailEditingViewControllerDelegate
+
 extension IssueDetailViewController: IssueDetailEditingViewControllerDelegate {
     func scrollUpButtonTabbed() {
-        print("up")
         let topPoint = CGPoint(x: 0, y: 0)
         collectionView.setContentOffset(topPoint, animated: true)
     }
     
     func scrollDownButtonTabbed() {
-        print("down")
         let bottomPoint = CGPoint(x: 0, y: collectionView.contentSize.height - collectionView.frame.height)
         collectionView.setContentOffset(bottomPoint, animated: true)
     }
     
     func addCommentButtonTabbed() {
-        print("button")
-        // TODO: 이슈 생성 화면을 보여준다.
+        
     }
     
 }

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/ViewModel/IssueDetailViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/ViewModel/IssueDetailViewModel.swift
@@ -11,22 +11,24 @@ class IssueDetailViewModel {
     }
     
     struct Action {
-        // Edit 버튼
-        // 스와이프
-        // 댓글 추가 버튼
-        // 스크롤 버튼
-        var editIssueTabbed: (Int) -> Void
+        var refreshData: () -> Void
+        //var editIssueTabbed: (Int) -> Void
     }
     
     var status: Status
-    //var action: Action
+    lazy var action = Action(
+        refreshData: { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.service.requestIssueGet(with: weakSelf.issueId)
+        }
+    )
   
     var issueId: Int
  
     init(issueId: Int) {
         self.status = Status()
         self.issueId = issueId
-        service.callAPI(with: issueId)
+        service.requestIssueGet(with: issueId)
     }
 
     

--- a/iOS/IssueTracker/IssueTracker/IssueList/Model/IssueListModel.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/Model/IssueListModel.swift
@@ -7,19 +7,52 @@ struct IssueListModel: Codable, Hashable {
     var title: String
     var content: String?
     var isOpen: Bool
-    var mId: String? // 마일스톤 아이디
     var labels: [Label]?
     var assignees: [Assignees]?
     var user: User
     var comments: [IssueListComment]?
-    var isSelected: Bool? = false
+    var isSelected: Bool = false
+//
+    init(iid: Int, title: String, content: String? = nil, isOpen: Bool,labels:[Label]? = nil,
+         assignees: [Assignees]? = nil, user: User, comments: [IssueListComment]? = nil) {
+        self.iid = iid
+        self.title = title
+        self.content = content
+        self.isOpen = isOpen
+        self.labels = labels
+        self.assignees = assignees
+        self.user = user
+        self.comments = comments
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case iid
+        case title
+        case content
+        case isOpen
+        case labels
+        case assignees
+        case user
+        case comments
+    }
+    
+    init(from decoder: Decoder) throws {
+        let value  = try decoder.container(keyedBy: CodingKeys.self)
+        iid = try value.decode(Int.self, forKey: .iid)
+        title = try value.decode(String.self, forKey: .title)
+        content = try value.decode(String?.self, forKey: .content)
+        isOpen = try value.decode(Bool.self, forKey: .isOpen)
+        labels = try value.decode([Label]?.self, forKey: .labels)
+        assignees = try value.decode([Assignees]?.self, forKey: .assignees)
+        user = try value.decode(User.self, forKey: .user)
+        comments = try value.decode([IssueListComment]?.self, forKey: .comments)
+    }
     
     static func == (lhs: IssueListModel, rhs: IssueListModel) -> Bool {
         return lhs.iid == rhs.iid
             && lhs.title == rhs.title
             && lhs.content == rhs.content
             && lhs.isOpen == rhs.isOpen
-            && lhs.mId == rhs.mId
             && lhs.labels == rhs.labels
             && lhs.assignees == rhs.assignees
             && lhs.user == rhs.user
@@ -32,7 +65,6 @@ struct IssueListModel: Codable, Hashable {
         hasher.combine(title)
         hasher.combine(content)
         hasher.combine(isOpen)
-        hasher.combine(mId)
         hasher.combine(labels)
         hasher.combine(assignees)
         hasher.combine(comments)
@@ -47,7 +79,6 @@ struct IssueListModel: Codable, Hashable {
                 title: "testtesttest",
                 content: "Hello",
                 isOpen: true,
-                mId: nil,
                 labels: Label.all(), user: User(uid: 1, userId: "123123", nickname: "123123"))
         )
         newModel.append(
@@ -56,7 +87,54 @@ struct IssueListModel: Codable, Hashable {
                 title: "bugs",
                 content: nil,
                 isOpen: false,
-                mId: nil,
+                labels: Label.all(), user: User(uid: 2, userId: "123124", nickname: "123124"))
+        )
+        newModel.append(
+            IssueListModel(
+                iid: 55,
+                title: "bugs",
+                content: nil,
+                isOpen: false,
+                labels: Label.all(), user: User(uid: 2, userId: "123124", nickname: "123124"))
+        )
+        newModel.append(
+            IssueListModel(
+                iid: 25,
+                title: "bugs",
+                content: nil,
+                isOpen: false,
+                labels: Label.all(), user: User(uid: 2, userId: "123124", nickname: "123124"))
+        )
+        newModel.append(
+            IssueListModel(
+                iid: 225,
+                title: "bugs",
+                content: nil,
+                isOpen: false,
+                labels: Label.all(), user: User(uid: 2, userId: "123124", nickname: "123124"))
+        )
+        newModel.append(
+            IssueListModel(
+                iid: 235,
+                title: "bugs",
+                content: nil,
+                isOpen: false,
+                labels: Label.all(), user: User(uid: 2, userId: "123124", nickname: "123124"))
+        )
+        newModel.append(
+            IssueListModel(
+                iid: 325,
+                title: "bugs",
+                content: nil,
+                isOpen: false,
+                labels: Label.all(), user: User(uid: 2, userId: "123124", nickname: "123124"))
+        )
+        newModel.append(
+            IssueListModel(
+                iid: 2215,
+                title: "bugs",
+                content: nil,
+                isOpen: false,
                 labels: Label.all(), user: User(uid: 2, userId: "123124", nickname: "123124"))
         )
         return newModel

--- a/iOS/IssueTracker/IssueTracker/IssueList/View/IssueList.storyboard
+++ b/iOS/IssueTracker/IssueTracker/IssueList/View/IssueList.storyboard
@@ -158,16 +158,6 @@
                                             <rect key="frame" x="0.0" y="0.0" width="363" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gdk-LL-OiO">
-                                                    <rect key="frame" x="0.0" y="39" width="30" height="22"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="30" id="HiD-uD-vXR"/>
-                                                    </constraints>
-                                                    <state key="normal" image="circle" catalog="system"/>
-                                                    <connections>
-                                                        <action selector="checkButtonTabbed:" destination="nKv-YR-Rwv" eventType="touchUpInside" id="ake-sd-QDu"/>
-                                                    </connections>
-                                                </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j9l-dh-H69" userLabel="close">
                                                     <rect key="frame" x="0.0" y="0.0" width="72.5" height="100"/>
                                                     <color key="backgroundColor" red="0.1647058824" green="0.75686274509999996" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
@@ -256,16 +246,23 @@
                                                     </connections>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n2D-oL-lPd" userLabel="DetaileViewForMulti" customClass="IssueDetailedView" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="30" y="0.0" width="363" height="100"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="393" height="100"/>
                                                     <subviews>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gdk-LL-OiO">
+                                                            <rect key="frame" x="0.0" y="0.0" width="30" height="100"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="30" id="HiD-uD-vXR"/>
+                                                            </constraints>
+                                                            <state key="normal" image="circle" catalog="system"/>
+                                                        </button>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vmc-2j-Jcv">
-                                                            <rect key="frame" x="15" y="10" width="35" height="21.5"/>
+                                                            <rect key="frame" x="45" y="10" width="35" height="21.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2e6-zi-tHU">
-                                                            <rect key="frame" x="263" y="0.0" width="100" height="100"/>
+                                                            <rect key="frame" x="293" y="0.0" width="100" height="100"/>
                                                             <subviews>
                                                                 <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ktN-xf-ew7">
                                                                     <rect key="frame" x="27" y="10" width="46" height="30"/>
@@ -282,7 +279,7 @@
                                                             </constraints>
                                                         </view>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eot-oF-MWb">
-                                                            <rect key="frame" x="15" y="39.5" width="72.5" height="17"/>
+                                                            <rect key="frame" x="45" y="39.5" width="72.5" height="17"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.66422420739999999" green="0.66424006219999998" blue="0.66423153879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -290,32 +287,34 @@
                                                     </subviews>
                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     <constraints>
+                                                        <constraint firstAttribute="bottom" secondItem="Gdk-LL-OiO" secondAttribute="bottom" id="3Om-1t-JNR"/>
                                                         <constraint firstAttribute="trailing" secondItem="2e6-zi-tHU" secondAttribute="trailing" id="9b4-mC-8N1"/>
                                                         <constraint firstItem="2e6-zi-tHU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Vmc-2j-Jcv" secondAttribute="trailing" constant="20" id="JC6-re-aL1"/>
                                                         <constraint firstItem="Eot-oF-MWb" firstAttribute="leading" secondItem="Vmc-2j-Jcv" secondAttribute="leading" id="Nuq-JY-7cs"/>
                                                         <constraint firstItem="2e6-zi-tHU" firstAttribute="top" secondItem="n2D-oL-lPd" secondAttribute="top" id="Tz0-w4-R0u"/>
                                                         <constraint firstItem="Vmc-2j-Jcv" firstAttribute="top" secondItem="n2D-oL-lPd" secondAttribute="top" constant="10" id="Z8V-gD-BZa"/>
+                                                        <constraint firstItem="Gdk-LL-OiO" firstAttribute="leading" secondItem="n2D-oL-lPd" secondAttribute="leading" id="blp-Qf-6PK"/>
                                                         <constraint firstItem="Eot-oF-MWb" firstAttribute="top" secondItem="Vmc-2j-Jcv" secondAttribute="bottom" constant="8" symbolic="YES" id="eMe-Yg-Q00"/>
-                                                        <constraint firstItem="Vmc-2j-Jcv" firstAttribute="leading" secondItem="n2D-oL-lPd" secondAttribute="leading" constant="15" id="my0-ty-kIa"/>
+                                                        <constraint firstItem="Vmc-2j-Jcv" firstAttribute="leading" secondItem="n2D-oL-lPd" secondAttribute="leading" constant="45" id="my0-ty-kIa"/>
+                                                        <constraint firstItem="Gdk-LL-OiO" firstAttribute="top" secondItem="n2D-oL-lPd" secondAttribute="top" id="pW7-pM-lq9"/>
                                                         <constraint firstItem="2e6-zi-tHU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Eot-oF-MWb" secondAttribute="trailing" constant="20" id="r76-b3-vI3"/>
                                                         <constraint firstAttribute="bottom" secondItem="2e6-zi-tHU" secondAttribute="bottom" id="tHV-b3-9Lp"/>
                                                     </constraints>
                                                     <connections>
                                                         <outlet property="descriptionLabel" destination="Eot-oF-MWb" id="m7X-Ey-qAF"/>
+                                                        <outlet property="isChosenButton" destination="Gdk-LL-OiO" id="PVK-dC-d7K"/>
                                                         <outlet property="milestoneLabel" destination="ktN-xf-ew7" id="D1d-KS-rc3"/>
                                                         <outlet property="titleLabel" destination="Vmc-2j-Jcv" id="ol0-V0-ZEB"/>
                                                     </connections>
                                                 </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="Gdk-LL-OiO" firstAttribute="centerY" secondItem="EOG-bM-25o" secondAttribute="centerY" id="0hg-3p-DdF"/>
                                                 <constraint firstAttribute="trailing" secondItem="IYO-CD-0Xt" secondAttribute="trailing" id="COE-2z-T8V"/>
                                                 <constraint firstItem="XCL-1a-fTR" firstAttribute="top" secondItem="EOG-bM-25o" secondAttribute="top" id="FqB-a0-uLx"/>
                                                 <constraint firstItem="IYO-CD-0Xt" firstAttribute="leading" secondItem="EOG-bM-25o" secondAttribute="leading" id="KFk-Bz-SDd"/>
                                                 <constraint firstAttribute="bottom" secondItem="IYO-CD-0Xt" secondAttribute="bottom" id="NYB-9y-znY"/>
                                                 <constraint firstAttribute="bottom" secondItem="n2D-oL-lPd" secondAttribute="bottom" id="Qun-MU-ekH"/>
                                                 <constraint firstAttribute="bottom" secondItem="j9l-dh-H69" secondAttribute="bottom" id="TCW-eV-JDh"/>
-                                                <constraint firstItem="Gdk-LL-OiO" firstAttribute="leading" secondItem="EOG-bM-25o" secondAttribute="leading" id="X7A-Tm-cLl"/>
                                                 <constraint firstItem="j9l-dh-H69" firstAttribute="leading" secondItem="EOG-bM-25o" secondAttribute="leading" id="Xa0-iH-xP3"/>
                                                 <constraint firstItem="n2D-oL-lPd" firstAttribute="top" secondItem="EOG-bM-25o" secondAttribute="top" id="ZQb-9S-3ix"/>
                                                 <constraint firstAttribute="trailing" secondItem="XCL-1a-fTR" secondAttribute="trailing" id="cWx-2F-og1"/>
@@ -325,13 +324,12 @@
                                                 <constraint firstItem="XCL-1a-fTR" firstAttribute="width" secondItem="EOG-bM-25o" secondAttribute="width" multiplier="0.2" id="uJ6-Wa-fm0"/>
                                                 <constraint firstAttribute="bottom" secondItem="XCL-1a-fTR" secondAttribute="bottom" id="v3J-Ps-DoP"/>
                                                 <constraint firstAttribute="trailing" secondItem="n2D-oL-lPd" secondAttribute="trailing" constant="-30" id="vCm-nW-1Qm"/>
-                                                <constraint firstItem="n2D-oL-lPd" firstAttribute="leading" secondItem="EOG-bM-25o" secondAttribute="leading" constant="30" id="w97-dK-q3j"/>
+                                                <constraint firstItem="n2D-oL-lPd" firstAttribute="leading" secondItem="EOG-bM-25o" secondAttribute="leading" id="w97-dK-q3j"/>
                                             </constraints>
                                         </collectionViewCellContentView>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <size key="customSize" width="363" height="100"/>
                                         <connections>
-                                            <outlet property="checkButton" destination="Gdk-LL-OiO" id="fV5-dp-7nh"/>
                                             <outlet property="closeButton" destination="j9l-dh-H69" id="tMj-3J-yEF"/>
                                             <outlet property="detailView" destination="IYO-CD-0Xt" id="8wf-GC-57a"/>
                                             <outlet property="detailViewForMulti" destination="n2D-oL-lPd" id="9u0-yB-tsx"/>

--- a/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueListMainViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueListMainViewController.swift
@@ -52,6 +52,7 @@ class IssueListMainViewController: UIViewController {
         let creationVC:IssueCreationViewController = UIStoryboard(name: "IssueCreation", bundle: nil)
             .instantiateViewController(
                 identifier: String(describing: IssueCreationViewController.self))
+        creationVC.refresh = viewModel.action.refreshData
         self.present(creationVC, animated: true)
     }
     

--- a/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueResultList/IssueDetailedView.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueResultList/IssueDetailedView.swift
@@ -6,10 +6,21 @@ class IssueDetailedView: BothSidesSwipingView {
     @IBOutlet weak var milestoneLabel: UIButton!
     @IBOutlet weak var labelLabel: UILabel!
     
-    func setup(title: String, description: String) {
+    @IBOutlet weak var isChosenButton: UIButton?
+    
+    func setup(title: String, description: String, isChosen: Bool?) {
         titleLabel.text = title
         descriptionLabel.text = description
         configureMilestoneLable()
+        guard let isChosen = isChosen else { return }
+        guard let button = isChosenButton else { return }
+        if isChosen == true {
+            guard let checkedImage = UIImage(systemName: "circle.fill") else { return }
+            button.setImage(checkedImage, for: .normal)
+        } else {
+            guard let uncheckedImage = UIImage(systemName: "circle") else { return }
+            button.setImage(uncheckedImage, for: .normal)
+        }
     }
     
     func configureMilestoneLable() {

--- a/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueResultList/IssueResultCellView.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/View/Main/IssueResultList/IssueResultCellView.swift
@@ -7,17 +7,12 @@ enum IssueResultCellViewType {
 
 class IssueResultCellView: UICollectionViewCell {
     
-    override func prepareForReuse() {
-        
-    }
-    
     
     var iid: Int?
     var isChosen: Bool? = false
     
     @IBOutlet weak var detailView: IssueDetailedView!
     @IBOutlet weak var detailViewForMulti: IssueDetailedView!
-    @IBOutlet weak var checkButton: UIButton!
     @IBOutlet weak var closeButton: UIButton!
     
     var closeButtonAction: ((Int) -> Void)?
@@ -28,30 +23,30 @@ class IssueResultCellView: UICollectionViewCell {
         switch type {
         case .IssueListResult:
             detailViewForMulti.isHidden = true
-            detailView.setup(title: title, description: description)
+            detailView.setup(title: title, description: description, isChosen: isChosen)
         case .MultiSelectedView:
             closeButton.isHidden = true
             detailView.isHidden = true
-            detailViewForMulti.setup(title: title, description: description)
+            detailViewForMulti.setup(title: title, description: description, isChosen: isChosen)
             detailViewForMulti.stopSwipe(to: .right)
             detailViewForMulti.stopSwipe(to: .left)
         }
         
         self.iid = iid
         
-        guard let newIsSelected = isChosen else { return }
-        guard let oldIsSelected = self.isChosen else { return }
-        
-        if newIsSelected != oldIsSelected {
-            if newIsSelected == true {
-                guard let checkedImage = UIImage(systemName: "circle.fill") else { return }
-                checkButton.setImage(checkedImage, for: .normal)
-            } else {
-                guard let uncheckedImage = UIImage(systemName: "circle") else { return }
-                checkButton.setImage(uncheckedImage, for: .normal)
-            }
-        }
-        self.isChosen = newIsSelected
+//        guard let newIsSelected = isChosen else { return }
+//        guard let oldIsSelected = self.isChosen else { return }
+//
+//        if newIsSelected != oldIsSelected {
+//            if newIsSelected == true {
+//                guard let checkedImage = UIImage(systemName: "circle.fill") else { return }
+//                checkButton.setImage(checkedImage, for: .normal)
+//            } else {
+//                guard let uncheckedImage = UIImage(systemName: "circle") else { return }
+//                checkButton.setImage(uncheckedImage, for: .normal)
+//            }
+//        }
+//        self.isChosen = newIsSelected
         
     }
 //    

--- a/iOS/IssueTracker/IssueTracker/MilestoneList/VIewModel/MilestoneListViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/MilestoneList/VIewModel/MilestoneListViewModel.swift
@@ -64,7 +64,8 @@ class MilestoneListViewModel {
         }, refreshData: { [weak self] in
             guard let weakSelf = self else { return }
             weakSelf.service.requestMilestoneGet()
-        })
+        }
+    )
     
     var status = Status()
     

--- a/iOS/IssueTracker/IssueTracker/MilestoneList/View/MilestoneList.storyboard
+++ b/iOS/IssueTracker/IssueTracker/MilestoneList/View/MilestoneList.storyboard
@@ -35,84 +35,112 @@
                                             <rect key="frame" x="0.0" y="0.0" width="409" height="107"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 6월 19일까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bsW-b5-iY6">
-                                                    <rect key="frame" x="67" y="20" width="83.5" height="11"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="9"/>
-                                                    <color key="textColor" systemColor="systemGrayColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="64%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DOz-pJ-kPI">
-                                                    <rect key="frame" x="357.5" y="15" width="36.5" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.30840110780000002" green="0.5618229508" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="23 closed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hyh-Nz-hp5">
-                                                    <rect key="frame" x="330" y="75" width="64" height="17"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kna-u0-4UJ">
-                                                    <rect key="frame" x="15" y="13" width="42" height="25"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="25" id="1pD-XS-NpA"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <state key="normal" title="스프린트">
-                                                        <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6oo-kS-zcI">
+                                                    <rect key="frame" x="327" y="0.0" width="82" height="107"/>
+                                                    <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                                    <state key="normal" title="Delete">
+                                                        <color key="titleColor" systemColor="systemBackgroundColor"/>
                                                     </state>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                                            <real key="value" value="1"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                            <real key="value" value="5"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                                            <color key="value" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
+                                                    <connections>
+                                                        <action selector="deleteButtonTabbed:" destination="kxw-PZ-ddd" eventType="touchUpInside" id="YRB-rs-cXT"/>
+                                                    </connections>
                                                 </button>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="13 open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="907-Vv-R9A">
-                                                    <rect key="frame" x="342" y="55" width="52" height="17"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이번 배포를 위한 스프린트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q4T-JE-kyM">
-                                                    <rect key="frame" x="15" y="64" width="165" height="19.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ozU-IZ-x58" customClass="MilestoneListCellSwipeView" customModule="IssueTracker" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="0.0" width="409" height="107"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="64%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DOz-pJ-kPI">
+                                                            <rect key="frame" x="357.5" y="19" width="36.5" height="21"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <color key="textColor" red="0.30840110780000002" green="0.5618229508" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="23 closed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hyh-Nz-hp5">
+                                                            <rect key="frame" x="330" y="72" width="64" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kna-u0-4UJ">
+                                                            <rect key="frame" x="15" y="21" width="42" height="25"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="25" id="1pD-XS-NpA"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <state key="normal" title="스프린트">
+                                                                <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            </state>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                                    <real key="value" value="1"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                    <real key="value" value="5"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                                <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                    <color key="value" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </button>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="13 open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="907-Vv-R9A">
+                                                            <rect key="frame" x="342" y="50" width="52" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이번 배포를 위한 스프린트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q4T-JE-kyM">
+                                                            <rect key="frame" x="16" y="64" width="165" height="19.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                            <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 6월 19일까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bsW-b5-iY6">
+                                                            <rect key="frame" x="62" y="29.5" width="83.5" height="11"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="9"/>
+                                                            <color key="textColor" systemColor="systemGrayColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                    <constraints>
+                                                        <constraint firstItem="q4T-JE-kyM" firstAttribute="leading" secondItem="ozU-IZ-x58" secondAttribute="leading" constant="16" id="5Aa-Hg-7O5"/>
+                                                        <constraint firstItem="907-Vv-R9A" firstAttribute="centerY" secondItem="ozU-IZ-x58" secondAttribute="centerY" constant="5" id="5MP-fP-xZe"/>
+                                                        <constraint firstItem="Hyh-Nz-hp5" firstAttribute="top" secondItem="907-Vv-R9A" secondAttribute="bottom" constant="5" id="7aj-JX-cYZ"/>
+                                                        <constraint firstItem="kna-u0-4UJ" firstAttribute="leading" secondItem="ozU-IZ-x58" secondAttribute="leading" constant="15" id="7dl-hC-E89"/>
+                                                        <constraint firstItem="kna-u0-4UJ" firstAttribute="centerY" secondItem="ozU-IZ-x58" secondAttribute="centerY" constant="-20" id="7qk-ku-OyN"/>
+                                                        <constraint firstItem="DOz-pJ-kPI" firstAttribute="trailing" secondItem="907-Vv-R9A" secondAttribute="trailing" id="EC4-U1-pcv"/>
+                                                        <constraint firstItem="q4T-JE-kyM" firstAttribute="centerY" secondItem="ozU-IZ-x58" secondAttribute="centerY" constant="20" id="HVS-ab-drm"/>
+                                                        <constraint firstItem="bsW-b5-iY6" firstAttribute="leading" secondItem="kna-u0-4UJ" secondAttribute="trailing" constant="5" id="UNv-Xz-PDK"/>
+                                                        <constraint firstItem="bsW-b5-iY6" firstAttribute="firstBaseline" secondItem="kna-u0-4UJ" secondAttribute="firstBaseline" id="feJ-PZ-aHV"/>
+                                                        <constraint firstItem="Hyh-Nz-hp5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="bsW-b5-iY6" secondAttribute="trailing" constant="10" id="jt9-Hy-I1U"/>
+                                                        <constraint firstItem="Hyh-Nz-hp5" firstAttribute="trailing" secondItem="907-Vv-R9A" secondAttribute="trailing" id="v6W-wa-tED"/>
+                                                        <constraint firstItem="907-Vv-R9A" firstAttribute="top" secondItem="DOz-pJ-kPI" secondAttribute="bottom" constant="10" id="z0f-kF-oLq"/>
+                                                        <constraint firstAttribute="trailing" secondItem="907-Vv-R9A" secondAttribute="trailing" constant="15" id="zbh-fh-IDu"/>
+                                                    </constraints>
+                                                    <connections>
+                                                        <outlet property="closedLabel" destination="Hyh-Nz-hp5" id="bX9-rd-lxK"/>
+                                                        <outlet property="descriptionLabel" destination="q4T-JE-kyM" id="H05-0e-lpE"/>
+                                                        <outlet property="dueDateLabel" destination="bsW-b5-iY6" id="zn2-ns-8IR"/>
+                                                        <outlet property="milestoneTitle" destination="kna-u0-4UJ" id="zun-0t-X9Z"/>
+                                                        <outlet property="openLabel" destination="907-Vv-R9A" id="9wr-bh-Eap"/>
+                                                        <outlet property="percentageLabel" destination="DOz-pJ-kPI" id="s1y-Hq-QJp"/>
+                                                    </connections>
+                                                </view>
                                             </subviews>
                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
-                                                <constraint firstItem="Hyh-Nz-hp5" firstAttribute="top" secondItem="907-Vv-R9A" secondAttribute="bottom" constant="3" id="2sv-Q7-wQd"/>
-                                                <constraint firstItem="907-Vv-R9A" firstAttribute="trailing" secondItem="DOz-pJ-kPI" secondAttribute="trailing" id="BR0-BZ-tax"/>
-                                                <constraint firstItem="DOz-pJ-kPI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="bsW-b5-iY6" secondAttribute="trailing" constant="10" id="NVS-RP-5Gm"/>
-                                                <constraint firstItem="DOz-pJ-kPI" firstAttribute="top" secondItem="bxR-pG-a4x" secondAttribute="top" constant="15" id="OFa-9F-POs"/>
-                                                <constraint firstItem="kna-u0-4UJ" firstAttribute="centerY" secondItem="bsW-b5-iY6" secondAttribute="centerY" id="Rt5-Jf-5K9"/>
-                                                <constraint firstAttribute="trailing" secondItem="DOz-pJ-kPI" secondAttribute="trailing" constant="15" id="UOH-CW-dn1"/>
-                                                <constraint firstItem="Hyh-Nz-hp5" firstAttribute="trailing" secondItem="DOz-pJ-kPI" secondAttribute="trailing" id="W1X-Ih-y8m"/>
-                                                <constraint firstItem="q4T-JE-kyM" firstAttribute="leading" secondItem="kna-u0-4UJ" secondAttribute="leading" id="ZCW-az-Wez"/>
-                                                <constraint firstItem="Hyh-Nz-hp5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="q4T-JE-kyM" secondAttribute="trailing" constant="10" id="ZlK-02-Dhd"/>
-                                                <constraint firstItem="kna-u0-4UJ" firstAttribute="leading" secondItem="bxR-pG-a4x" secondAttribute="leading" constant="15" id="eSm-uk-AJa"/>
-                                                <constraint firstItem="q4T-JE-kyM" firstAttribute="centerY" secondItem="bxR-pG-a4x" secondAttribute="centerY" constant="20" id="jhJ-wL-C7n"/>
-                                                <constraint firstItem="bsW-b5-iY6" firstAttribute="leading" secondItem="kna-u0-4UJ" secondAttribute="trailing" constant="10" id="jkO-oT-Zuc"/>
-                                                <constraint firstItem="bsW-b5-iY6" firstAttribute="centerY" secondItem="DOz-pJ-kPI" secondAttribute="centerY" id="ne9-Rb-Y6G"/>
-                                                <constraint firstAttribute="bottom" secondItem="Hyh-Nz-hp5" secondAttribute="bottom" constant="15" id="nfy-uh-0Yu"/>
+                                                <constraint firstAttribute="trailing" secondItem="ozU-IZ-x58" secondAttribute="trailing" id="9ML-Ai-jjH"/>
+                                                <constraint firstItem="ozU-IZ-x58" firstAttribute="top" secondItem="bxR-pG-a4x" secondAttribute="top" id="FLC-RG-e6b"/>
+                                                <constraint firstAttribute="bottom" secondItem="6oo-kS-zcI" secondAttribute="bottom" id="INz-jG-B8q"/>
+                                                <constraint firstItem="6oo-kS-zcI" firstAttribute="width" secondItem="bxR-pG-a4x" secondAttribute="width" multiplier="0.2" id="RXp-Nd-TQ4"/>
+                                                <constraint firstAttribute="trailing" secondItem="6oo-kS-zcI" secondAttribute="trailing" id="TV9-9U-YWp"/>
+                                                <constraint firstItem="ozU-IZ-x58" firstAttribute="leading" secondItem="bxR-pG-a4x" secondAttribute="leading" id="a13-8O-DWU"/>
+                                                <constraint firstItem="6oo-kS-zcI" firstAttribute="top" secondItem="bxR-pG-a4x" secondAttribute="top" id="o0v-au-cfG"/>
+                                                <constraint firstAttribute="bottom" secondItem="ozU-IZ-x58" secondAttribute="bottom" id="wgI-Nj-f6W"/>
                                             </constraints>
                                         </collectionViewCellContentView>
                                         <size key="customSize" width="409" height="107"/>
                                         <connections>
-                                            <outlet property="closedLabel" destination="Hyh-Nz-hp5" id="b2j-Kx-fBx"/>
-                                            <outlet property="descriptionLabel" destination="q4T-JE-kyM" id="a9a-8k-jcZ"/>
-                                            <outlet property="dueDateLabel" destination="bsW-b5-iY6" id="O4F-dP-1CO"/>
-                                            <outlet property="milestoneTitle" destination="kna-u0-4UJ" id="6Ul-qB-KBb"/>
-                                            <outlet property="openLabel" destination="907-Vv-R9A" id="nVy-Gf-7by"/>
-                                            <outlet property="percentageLabel" destination="DOz-pJ-kPI" id="SM5-1X-Pmg"/>
+                                            <outlet property="detailView" destination="ozU-IZ-x58" id="sQr-rQ-kRj"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -370,6 +398,9 @@
         </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/MilestoneList/View/MilestoneListViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/MilestoneList/View/MilestoneListViewCell.swift
@@ -1,10 +1,32 @@
 
 import UIKit
 
+protocol MilestoneListCellViewDelegate {
+    func milestoneListCellView(_ milestoneViewCell: MilestoneListViewCell,  didSelectCellView: BothSidesSwipingView)
+}
 
 class MilestoneListViewCell: UICollectionViewCell {
 
-    var milestone: Milestone!
+    var delegate: MilestoneListCellViewDelegate?
+    
+    var milestone: Milestone {
+        detailView.milestone
+    }
+    
+    @IBOutlet weak var detailView: MilestoneListCellSwipeView!
+    
+    @IBAction func deleteButtonTabbed(_ sender: UIButton!) {
+        delegate?.milestoneListCellView(self, didSelectCellView: detailView)
+    }
+    
+    func setup(with milestone: Milestone) {
+        detailView.setup(with: milestone)
+        detailView.stopSwipe(to: .right)
+    }
+    
+}
+
+class MilestoneListCellSwipeView: BothSidesSwipingView {
     
     @IBOutlet var milestoneTitle: UIButton!
     @IBOutlet var dueDateLabel: UILabel!
@@ -13,6 +35,7 @@ class MilestoneListViewCell: UICollectionViewCell {
     @IBOutlet var openLabel: UILabel!
     @IBOutlet var closedLabel: UILabel!
     
+    var milestone: Milestone!
     var issueStates: [IssueState]?
     
     func setup(with milestone: Milestone) {
@@ -26,8 +49,6 @@ class MilestoneListViewCell: UICollectionViewCell {
         openLabel.text = "\(numberOfOpen ?? 0) open"
         closedLabel.text = "\(numberOfOpen ?? 0) closed"
         setupMilestoneTitleLabel()
-        
-        
     }
     
     func setupMilestoneTitleLabel() {
@@ -67,4 +88,11 @@ class MilestoneListViewCell: UICollectionViewCell {
         return Int(Float(open) / Float(open + close))
     }
     
+    
+    override func reset() {
+        super.reset()
+        self.stopSwipe(to: .right)
+    }
 }
+
+

--- a/iOS/IssueTracker/IssueTracker/MilestoneList/View/MilestoneListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MilestoneList/View/MilestoneListViewController.swift
@@ -88,12 +88,20 @@ class MilestoneListViewController: UIViewController {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MilestoneListViewCell", for: indexPath) as? MilestoneListViewCell else {
                     return nil
                 }
+                cell.delegate = self
                 cell.setup(with: milestone)
                 return cell
             })
     }
 
 }
+
+extension MilestoneListViewController: MilestoneListCellViewDelegate {
+    func milestoneListCellView(_ milestoneViewCell: MilestoneListViewCell, didSelectCellView: BothSidesSwipingView) {
+        viewModel.action.deleteButtonTabbed(milestoneViewCell.milestone.mid)
+    }
+}
+
 
 extension MilestoneListViewController: MilestoneEditingViewControllerDelegate {
     func MilestoneEditSaveButtonDidTab(title: String, description: String?, date: String, milestoneID: Int?) {
@@ -117,16 +125,3 @@ extension MilestoneListViewController {
 }
 
 
-#if DEBUG
-
-import SwiftUI
-
-struct MilestoneListViewController_Preview: PreviewProvider {
-    static var previews: some View {
-        let vc = UIStoryboard(name: "MilestoneList", bundle: nil)
-            .instantiateViewController(identifier: String(describing: MilestoneListViewController.self))
-        return vc.view.liveView
-    }
-}
-
-#endif

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/Service/MultiSelectiveEditingService.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/Service/MultiSelectiveEditingService.swift
@@ -6,7 +6,7 @@ class MultiSelectiveEditingService {
     let port: Int = 49203
     lazy var issueAPIURL = "http://group05issuetracker.duckdns.org:\(port)/api/issue/"
     
-    let httpHeaders:HTTPHeaders
+    let httpHeaders: HTTPHeaders
     
     unowned var viewModel: MultiSelectiveEditingViewModel
     

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/Service/MultiSelectiveEditingService.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/Service/MultiSelectiveEditingService.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Alamofire
+
+class MultiSelectiveEditingService {
+    
+    let port: Int = 49203
+    lazy var issueAPIURL = "http://group05issuetracker.duckdns.org:\(port)/api/issue/"
+    
+    let httpHeaders:HTTPHeaders
+    
+    unowned var viewModel: MultiSelectiveEditingViewModel
+    
+    init(viewModel: MultiSelectiveEditingViewModel) {
+        self.viewModel = viewModel
+        httpHeaders
+            = ["Accept": "application/json",
+               "Authorization": "Bearer \(UserDefaults.standard.string(forKey: "token")!)"]
+    }
+    
+    //MARK: POST
+    func requestIssueClose(issueId: Int) {
+        
+        let issueParameter = ["isOpen": "\(false)"]
+        
+        AF.request(issueAPIURL + "\(issueId)",
+                   method: .patch,
+                   parameters: issueParameter,
+                   headers: httpHeaders)
+            .responseData { response in
+                switch response.result {
+                case .success(let data):
+                    print("success",data)
+                case .failure(let error):
+                    print("error",error)
+                }
+            }
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
@@ -45,7 +45,17 @@ class MultiSelectiveEditingViewController: UIViewController {
     }
     
     @objc func selectAllButtonTabbed() {
-        
+        let nowTitle = navigationItem.leftBarButtonItem?.title
+        if nowTitle == "Select All" {
+            navigationItem.leftBarButtonItem?.title = "Deselect All"
+            navigationItem.leftBarButtonItem?.tintColor = .red
+            viewModel.action.selectAll()
+        } else {
+            navigationItem.leftBarButtonItem?.title = "Select All"
+            navigationItem.leftBarButtonItem?.tintColor = .systemBlue
+            viewModel.action.deSelectAll()
+            
+        }
     }
     
     @objc func closeButtonTabbed() {

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
@@ -52,19 +52,7 @@ class MultiSelectiveEditingViewController: UIViewController {
     }
     
     @objc func selectAllButtonTabbed() {
-        //        collectionView
-        //         콜렉션 뷰를 모두 돌면서 버튼 이미지를 모두 true로?
-//        print(resultViewController.collectionview.numberOfItems(inSection: 0))
-//
-//        (0..<resultViewController.collectionview.numberOfItems(inSection: 0)).indices.forEach{
-//            let indexPath = IndexPath(row: $0, section: 0)
-//            guard let cell = resultViewController.collectionview.cellForItem(at: indexPath)
-//                    as? IssueResultCellView else { return }
-//            // 여기서 무언가를 하면 된다!
-//            print(cell.iid!)
-//            cell.isCheck = true
-//            cell.drawCheckButton()
-//        }
+        
     }
     
     @objc func closeButtonTabbed() {

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
@@ -1,13 +1,6 @@
 import UIKit
 
-// 선택 이슈 닫기 누르면 선택된 데이터들 이전 vc(이슈 리스트)로 넘겨준다.
-// 이를 위해 델리게이트를 만들고, 종료 될 때 호출 한다.
-// 이슈리스트는 델리게이트를 호출하여 원하는 정보를 받아 간다.
-// -> 근데 그냥 서버 요청하면 끝날 것 같다!
-
 class MultiSelectiveEditingViewController: UIViewController {
-    
-    //var selectedIssues: [IssueListModel]?
     
     var viewModel: MultiSelectiveEditingViewModel!
     
@@ -56,6 +49,7 @@ class MultiSelectiveEditingViewController: UIViewController {
     }
     
     @objc func closeButtonTabbed() {
+        
         navigationController?.popViewController(animated: false)
     }
     
@@ -87,13 +81,7 @@ extension MultiSelectiveEditingViewController: UICollectionViewDelegate {
         guard let cell = collectionView.cellForItem(at: indexPath)
                 as? IssueResultCellView else { return }
         guard let id = cell.iid else { return }
-        //cell.drawCheckButton()
         viewModel.action.cellTouched(id)
     }
-    
-//    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-//        guard let cell = cell as? IssueResultCellView else { return }
-//        //cell.drawCheckButton()
-//    }
     
 }

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
@@ -12,8 +12,6 @@ class MultiSelectiveEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationController?.navigationBar.prefersLargeTitles = true
-        self.navigationController?.navigationBar.isHidden = false
         setupNavigationBarItem()
         setupTabBarButton()
         setupResultViewController()
@@ -79,9 +77,15 @@ class MultiSelectiveEditingViewController: UIViewController {
     
     func setupNavigationBarItem() {
         navigationItem.leftBarButtonItem =
-            UIBarButtonItem(title: "Select All", style: .done, target: self, action: #selector(selectAllButtonTabbed))
+            UIBarButtonItem(title: "Select All",
+                            style: .done,
+                            target: self,
+                            action: #selector(selectAllButtonTabbed))
         navigationItem.rightBarButtonItem =
-            UIBarButtonItem(title: "Cancel", style: .done, target: self, action: #selector(closeButtonTabbed))
+            UIBarButtonItem(title: "Cancel",
+                            style: .done,
+                            target: self,
+                            action: #selector(closeButtonTabbed))
     }
     
 }

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/View/MultiSelectiveEditingViewController.swift
@@ -12,19 +12,19 @@ class MultiSelectiveEditingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // 타이틀에 선택 개수가 나오도록 해야 한다.
-        
+        navigationController?.navigationBar.prefersLargeTitles = true
+        self.navigationController?.navigationBar.isHidden = false
         setupNavigationBarItem()
         setupTabBarButton()
         setupResultViewController()
         resultViewController.collectionview.delegate = self
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         viewModel.status.issues
             .bindAndFire(resultViewController.applySnapshot(sections:))
+        viewModel.status.title.bindAndFire(setSelectedNumberTitle)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -34,6 +34,10 @@ class MultiSelectiveEditingViewController: UIViewController {
     
     
     // MARK: Action
+    
+    func setSelectedNumberTitle(title: String) {
+        navigationItem.title = title
+    }
     
     @IBAction func closeSelectedIssues(_ sender: UIButton) {
         viewModel.action.closeSelectedIssues()
@@ -54,12 +58,10 @@ class MultiSelectiveEditingViewController: UIViewController {
             navigationItem.leftBarButtonItem?.title = "Select All"
             navigationItem.leftBarButtonItem?.tintColor = .systemBlue
             viewModel.action.deSelectAll()
-            
         }
     }
     
     @objc func closeButtonTabbed() {
-        
         navigationController?.popViewController(animated: false)
     }
     
@@ -70,10 +72,8 @@ class MultiSelectiveEditingViewController: UIViewController {
         resultViewController = UIStoryboard(name: "IssueList", bundle: nil)
             .instantiateViewController(
                 identifier: String(describing: IssueResultViewController.self))
-        
         resultViewController.view.frame = resultContainerView.bounds
         resultContainerView.addSubview(resultViewController.view)
-        
         resultViewController.cellType = .MultiSelectedView
     }
     
@@ -85,6 +85,9 @@ class MultiSelectiveEditingViewController: UIViewController {
     }
     
 }
+
+
+// MARK: CollectionView Delegate
 
 extension MultiSelectiveEditingViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
@@ -4,10 +4,14 @@ class MultiSelectiveEditingViewModel {
     
     lazy var service = MultiSelectiveEditingService(viewModel: self)
     
+    var countOfSelectedTitle: String {
+        "\(self.status.issues.value.filter { $0.isSelected }.count)개 선택"
+    }
+    
+    
     struct Status {
         var issues: Bindable<[IssueListModel]>
-        //var selectButtonTitle: Bindable<String>("Select All")
-        // selectedCount -> title로 사용 - 선택할 때 마다 얘를 업데이트 해준다. 긜고 타이틀 변경함수를 바인딩해 놓는다.
+        var title = Bindable("0개 선택")
     }
     
     struct Action {
@@ -18,22 +22,24 @@ class MultiSelectiveEditingViewModel {
     }
     
     var status: Status
+    
     lazy var action = Action(
         cellTouched: { [weak self] id in
             guard let weakSelf = self else { return }
             var issues = weakSelf.status.issues.value
             for index in issues.indices {
                 if issues[index].iid == id {
-                    print("여기인가\(id)")
                     issues[index].isSelected.toggle()
                 }
             }
             weakSelf.status.issues.value = issues // 발생
+            weakSelf.status.title.value = weakSelf.countOfSelectedTitle
         }, closeSelectedIssues: { [weak self] in
             guard let weakSelf = self else { return }
             weakSelf.status.issues.value.forEach {
                 weakSelf.service.requestIssueClose(issueId: $0.iid)
             }
+            weakSelf.status.title.value = weakSelf.countOfSelectedTitle
         }, selectAll: { [weak self] in
             guard let weakSelf = self else { return }
             weakSelf.status.issues.value
@@ -42,6 +48,7 @@ class MultiSelectiveEditingViewModel {
                     tempIssue.isSelected = true
                     return tempIssue
                 }
+            weakSelf.status.title.value = weakSelf.countOfSelectedTitle
         }, deSelectAll: { [weak self] in
             guard let weakSelf = self else { return }
             weakSelf.status.issues.value
@@ -50,6 +57,7 @@ class MultiSelectiveEditingViewModel {
                     tempIssue.isSelected = false
                     return tempIssue
                 }
+            weakSelf.status.title.value = weakSelf.countOfSelectedTitle
         }
     )
     

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
@@ -8,7 +8,6 @@ class MultiSelectiveEditingViewModel {
         "\(self.status.issues.value.filter { $0.isSelected }.count)개 선택"
     }
     
-    
     struct Status {
         var issues: Bindable<[IssueListModel]>
         var title = Bindable("0개 선택")
@@ -32,7 +31,7 @@ class MultiSelectiveEditingViewModel {
                     issues[index].isSelected.toggle()
                 }
             }
-            weakSelf.status.issues.value = issues // 발생
+            weakSelf.status.issues.value = issues 
             weakSelf.status.title.value = weakSelf.countOfSelectedTitle
         }, closeSelectedIssues: { [weak self] in
             guard let weakSelf = self else { return }

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class MultiSelectiveEditingViewModel {
     
-    //var touchedIDs = [Int]() // 얘를 카운트 한 만큼 TiTle을 표시해야 한다. title에 관한 데이터 바인더블 필요
+    lazy var service = MultiSelectiveEditingService(viewModel: self)
     
     struct Status {
         var issues: Bindable<[IssueListModel]>
@@ -26,9 +26,11 @@ class MultiSelectiveEditingViewModel {
                 }
             }
             weakSelf.status.issues.value = issues // 발생
-        }, closeSelectedIssues: {
-            
-            
+        }, closeSelectedIssues: { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.status.issues.value.forEach {
+                weakSelf.service.requestIssueClose(issueId: $0.iid)
+            }
         })
     
     init(issues: [IssueListModel]) {

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
@@ -6,12 +6,15 @@ class MultiSelectiveEditingViewModel {
     
     struct Status {
         var issues: Bindable<[IssueListModel]>
+        //var selectButtonTitle: Bindable<String>("Select All")
         // selectedCount -> title로 사용 - 선택할 때 마다 얘를 업데이트 해준다. 긜고 타이틀 변경함수를 바인딩해 놓는다.
     }
     
     struct Action {
         var cellTouched: (Int) -> Void // 같은 게 있으면 지움 -> 필터로 어케 될 듯?
         var closeSelectedIssues: () -> Void
+        var selectAll: () -> Void
+        var deSelectAll: () -> Void
     }
     
     var status: Status
@@ -31,7 +34,24 @@ class MultiSelectiveEditingViewModel {
             weakSelf.status.issues.value.forEach {
                 weakSelf.service.requestIssueClose(issueId: $0.iid)
             }
-        })
+        }, selectAll: { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.status.issues.value
+                = weakSelf.status.issues.value.map {
+                    var tempIssue = $0
+                    tempIssue.isSelected = true
+                    return tempIssue
+                }
+        }, deSelectAll: { [weak self] in
+            guard let weakSelf = self else { return }
+            weakSelf.status.issues.value
+                = weakSelf.status.issues.value.map {
+                    var tempIssue = $0
+                    tempIssue.isSelected = false
+                    return tempIssue
+                }
+        }
+    )
     
     init(issues: [IssueListModel]) {
         status = Status(issues: Bindable(issues))

--- a/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/MultiSelectiveEditiView/ViewModel/MultiSelectiveEditingViewModel.swift
@@ -22,26 +22,13 @@ class MultiSelectiveEditingViewModel {
             for index in issues.indices {
                 if issues[index].iid == id {
                     print("여기인가\(id)")
-                    if var isSelected = issues[index].isSelected {
-                        isSelected.toggle()
-                        issues[index].isSelected = isSelected
-                    } else {
-                        issues[index].isSelected = true
-                    }
+                    issues[index].isSelected.toggle()
                 }
             }
             weakSelf.status.issues.value = issues // 발생
-
-            //
-//            for index in weakSelf.touchedIDs.indices {
-//                if weakSelf.touchedIDs[index] == id {
-//                    weakSelf.touchedIDs.remove(at: index)
-//                    return
-//                }
-//            }
-//            weakSelf.touchedIDs.append(id)
         }, closeSelectedIssues: {
-            // 해당 아이디 클로즈해달라고 서버 요청하고 끝
+            
+            
         })
     
     init(issues: [IssueListModel]) {


### PR DESCRIPTION
### 다중 선택 화면 구현 
- 치명적 오류
    - IssueListModel에서 isSelected jsonData를 받아오지 못해도 디코딩이 되도록 옵셔널로 처리했었습니다. 그런데 이렇게 하다보니 diffable에서 비교 연산을 제대로 수행하지 못했습니다. 이로 인해 체크를 한 번 했는데 여러 개가 동시에 선택되는 일이 벌어졌습니다. 
    - 그래서 IssueListModel의 코딩키 enum값을 정의하고 decoder init을 정의하여 json 디코딩 시에 isSelected값은 받아오지 않도록 하고 옵셔널을 해제 했습니다. 이렇게 했더니 바로 해결 되었습니다. 
- close button, selectAll/deselectAll 구현
    - 네비게이션 title을 설정할 때 viewDidLoad에서 하니까 화면에 표시되지 않았습니다. 그래서 viewWillAppear로 옮겨주었더니 잘되었습니다. 

### Milestone Delete 구현
- 스와이프로 delete를 구현하기 위해 기존에 cell 위에 구성되어 있던 UI 요소들을 스와이프 뷰로 이동했습니다. 

### Refresh 추가
- 이슈 디테일 화면에 refresh controller를 추가했습니다. 
- 이슈 추가/편집 화면에서 upload에 성공할 시, 돌아오는 화면의 내용을 reload하도록 수정하였습니다.
    - 클로저 사용
